### PR TITLE
Fix syntax in patchLauncher command

### DIFF
--- a/lib/app_version/app_version_check.dart
+++ b/lib/app_version/app_version_check.dart
@@ -48,7 +48,7 @@ Future<File> patchFileLauncherGenerate(String remoteVersion) async {
   if (!patchFile.existsSync()) {
     patchFile.createSync(recursive: true);
   }
-  String commands = 'start /B /D "${'${Directory.current.path}${p.separator}appUpdate${p.separator}'}" updater.exe PSO2NGSModManager $remoteVersion "${Directory.current.path}"';
+  String commands = 'start /B "" "${'${Directory.current.path}${p.separator}appUpdate${p.separator}updater.exe'}" PSO2NGSModManager $remoteVersion "${Directory.current.path}"';
   await patchFile.writeAsString(commands);
 
   return patchFile;


### PR DESCRIPTION
The pull request changes the syntax of the `start` CMD command found in `patchLauncher.bat` to prevent the program from first looking for `updater.exe` inside the Current Working Directory or the folders located in `PATH` before finally launching `updater.exe` from `appUpdate`.

Please note that we have to add an empty string towards the command which is used for the "Window Title", as otherwise it will attempt to set the directory specified as the window title and attempt to open a Command Prompt instead.

Intended change based on an example:

```
start /B /D "D:\PSO2 Mods\PSO2NGSModManager\appUpdate\" updater.exe PSO2NGSModManager 3.2.9 "D:\PSO2 Mods\PSO2NGSModManager"
```

becomes:

```
start /B "" "D:\PSO2 Mods\PSO2NGSModManager\appUpdate\updater.exe" PSO2NGSModManager 3.2.9 "D:\PSO2 Mods\PSO2NGSModManager"
```

This closes #358 .